### PR TITLE
Add randomized solution for C

### DIFF
--- a/c-randomized/abcdefghppp.c
+++ b/c-randomized/abcdefghppp.c
@@ -1,27 +1,27 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-
-#define MAX_TRIAL 1000000
+#include <time.h>
 
 int x[9];
 
 void randomize() {
     int i, j, y;
     for (i = 0; i < 9; i++) {
-        int ok = 0;
-        while (!ok) {
-            x[i] = rand() % 10;
-            ok = 1;
-            for (j = 0; j < i; j++) {
-                ok = ok && x[i] != x[j];
-            }
-        }
+        x[i] = rand() % 10;
     }
 }
 
 int correct() {
-    int i, ab, cd, ef, gh, ppp;
+    int i, vis[10], ab, cd, ef, gh, ppp;
+
+    memset(vis, 0, sizeof(vis));
+    for (i = 0; i < 9; i++) {
+        if (vis[x[i]]) {
+            return 0;
+        }
+        vis[x[i]] = 1;
+    }
 
     ab = x[0] * 10 + x[1];
     cd = x[2] * 10 + x[3];
@@ -31,12 +31,19 @@ int correct() {
     return (ab - cd) == ef && (ef + gh) == ppp;
 }
 
+void init() {
+    srand(time(0));
+    randomize();
+}
+
 int main() {
-    int t;
-    do {
+    int t = 0;
+
+    init();
+    // with this number of trials, there is 99.9978% chance returning an answer ;)
+    for (t = 1; !correct() && t > 0; t++) {
         randomize();
-        t++;
-    } while (!correct() && t <= MAX_TRIAL);
+    }
 
     if (correct()) {
         printf("Answer found at #%d trial%s.\n", t, t == 1 ? "": "s");

--- a/c-randomized/abcdefghppp.c
+++ b/c-randomized/abcdefghppp.c
@@ -1,0 +1,52 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define MAX_TRIAL 1000000
+
+int x[9];
+
+void randomize() {
+    int i, j, y;
+    for (i = 0; i < 9; i++) {
+        int ok = 0;
+        while (!ok) {
+            x[i] = rand() % 10;
+            ok = 1;
+            for (j = 0; j < i; j++) {
+                ok = ok && x[i] != x[j];
+            }
+        }
+    }
+}
+
+int correct() {
+    int i, ab, cd, ef, gh, ppp;
+
+    ab = x[0] * 10 + x[1];
+    cd = x[2] * 10 + x[3];
+    ef = x[4] * 10 + x[5];
+    gh = x[6] * 10 + x[7];
+    ppp = x[8] * 111;
+    return (ab - cd) == ef && (ef + gh) == ppp;
+}
+
+int main() {
+    int t;
+    do {
+        randomize();
+        t++;
+    } while (!correct() && t <= MAX_TRIAL);
+
+    if (correct()) {
+        printf("Answer found at #%d trial%s.\n", t, t == 1 ? "": "s");
+        printf(
+            "%1$d%2$d - %3$d%4$d = %5$d%6$d, %5$d%6$d + %7$d%8$d = %9$d%9$d%9$d\n",
+            x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8]
+        );
+    } else {
+        puts("I'm too stupid.");
+    }
+
+    return 0;
+}


### PR DESCRIPTION
I tried to implement a solution that could be worse than `random_shuffle`,
but unfortunately it still be able to return the first solution in 200ms

```
$ time ./abcdefghppp
Answer found at #222438 trials.
90 - 27 = 63, 63 + 48 = 111
./abcdefghppp  0.19s user 0.00s system 98% cpu 0.191 total
```
#### Updated

I think securing `randomize` will gives a valid permutation isn't a good approach,
now using a purely _ guess method, and with some calculation,
there is 99.9978% chance that the program will return a solution within `INT_MAX` number of trials

```
$ time ./abcdefghppp
Answer found at #29654447 trials.
34 - 09 = 25, 25 + 86 = 111
./abcdefghppp  3.34s user 0.00s system 99% cpu 3.342 total
```
